### PR TITLE
Rename PJfoot branding to Mister across repository content

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Report a problem with the PJfoot app
+about: Report a problem with the Mister app
 title: "[BUG] "
 labels: bug
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea or improvement for the PJfoot app
+about: Suggest an idea or improvement for the Mister app
 title: "[FEATURE] "
 labels: enhancement
 assignees: ''

--- a/.github/scripts/update-readme.py
+++ b/.github/scripts/update-readme.py
@@ -51,9 +51,9 @@ def parse_changelog(path):
         text = f.read()
     date_m = re.search(r"> Released: (\d{4}-\d{2}-\d{2})", text)
     date = date_m.group(1) if date_m else "2026-05-01"
-    # Title line: "# PJfoot v0.03 — Mobile UX, ..."
+    # Title line: "# Mister v0.03 — Mobile UX, ..."
     # Changelog files use an em-dash (U+2014) between version and title.
-    title_m = re.search(r"^# PJfoot \S+ \u2014 (.+)$", text, re.MULTILINE)
+    title_m = re.search(r"^# (?:Mister|PJfoot) \S+ [\u2014-] (.+)$", text, re.MULTILINE)
     title = title_m.group(1).strip() if title_m else version
     return version, date, title
 

--- a/.github/workflows/mirror-issues-to-private.yml
+++ b/.github/workflows/mirror-issues-to-private.yml
@@ -18,7 +18,7 @@ jobs:
           app-id: ${{ secrets.PJFOOT_MIRROR_APP_ID }}
           private-key: ${{ secrets.PJFOOT_MIRROR_APP_PRIVATE_KEY }}
           owner: pejota81
-          repositories: pjfoot
+          repositories: mister
 
       - name: Create issue in private repo
         env:
@@ -37,6 +37,6 @@ jobs:
 
           gh api \
             -X POST \
-            /repos/pejota81/pjfoot/issues \
+            /repos/pejota81/mister/issues \
             -f title="$SOURCE_TITLE" \
             -f body="$body"

--- a/.github/workflows/publish-changelog.yml
+++ b/.github/workflows/publish-changelog.yml
@@ -26,7 +26,7 @@ jobs:
           app-id: ${{ secrets.PJFOOT_MIRROR_APP_ID }}
           private-key: ${{ secrets.PJFOOT_MIRROR_APP_PRIVATE_KEY }}
           owner: pejota81
-          repositories: pjfoot
+          repositories: mister
 
       - name: Checkout destination repo
         uses: actions/checkout@v4

--- a/README.es.md
+++ b/README.es.md
@@ -1,15 +1,15 @@
 ```
 +-----------------------------------------------------------+
-|                          PJFOOT                           |
+|                          MISTER                           |
 |           Comunidad de Manager de Futbol Retro            |
 +-----------------------------------------------------------+
 ```
 
 Idioma: [English](README.md) | [Português (Brasil)](README.pt-BR.md) | **Español**
 
-# Bienvenido a PJfoot
+# Bienvenido a Mister
 
-¡Bienvenido a **PJfoot**, el simulador de manager de fútbol con estilo retro inspirado en el legendario Elifoot 98! Toma el control de tu club, construye tu plantilla ideal, gestiona la presión de la temporada y lleva a tu equipo al título.
+¡Bienvenido a **Mister**, el simulador de manager de fútbol con estilo retro inspirado en el legendario Elifoot 98! Toma el control de tu club, construye tu plantilla ideal, gestiona la presión de la temporada y lleva a tu equipo al título.
 
 ¿Tienes lo necesario para ser campeón? Este es tu desafío.
 
@@ -17,7 +17,7 @@ Idioma: [English](README.md) | [Português (Brasil)](README.pt-BR.md) | **Españ
 
 ## 🎮 Sobre el Juego
 
-PJfoot es un **simulador single-player de gestión de clubes de fútbol** con:
+Mister es un **simulador single-player de gestión de clubes de fútbol** con:
 
 - 🏆 **Competición Profunda de Ligas** – Compite en 9 divisiones dentro de un sistema global estructurado de ligas
 - 👥 **Gestión de Plantilla** – Arma tu equipo, administra la fatiga y desarrolla jóvenes talentos
@@ -79,7 +79,7 @@ PJfoot es un **simulador single-player de gestión de clubes de fútbol** con:
 
 ## 💬 Comparte tu Feedback
 
-¡Estamos construyendo PJfoot pensando en **ti**! Tu feedback define directamente el futuro del juego. Así puedes ayudar:
+¡Estamos construyendo Mister pensando en **ti**! Tu feedback define directamente el futuro del juego. Así puedes ayudar:
 
 ### 🐛 ¿Encontraste un Bug?
 ¿Algo no funciona como debería? [Abrir reporte de bug →](../../issues/new?template=bug_report.md)  
@@ -93,7 +93,7 @@ Propón nuevas mecánicas, mejoras o cualquier idea que quieras ver en el juego.
 ¿Quieres compartir opiniones, hacer preguntas o hablar con otros managers? Únete a nuestro [foro de Discussions →](../../discussions)  
 - Comparte estrategias y tácticas
 - Pregunta y recibe ayuda de la comunidad
-- Debate el futuro de PJfoot
+- Debate el futuro de Mister
 - Conecta con otros fans del fútbol
 
 ### 📋 Cómo dar un gran feedback
@@ -115,7 +115,7 @@ Propón nuevas mecánicas, mejoras o cualquier idea que quieras ver en el juego.
 
 ## 🏅 Nuestra Visión
 
-PJfoot es un proyecto hecho con pasión para recuperar la diversión de los clásicos managers de fútbol, incorporando funciones modernas y mejor accesibilidad. Creemos en:
+Mister es un proyecto hecho con pasión para recuperar la diversión de los clásicos managers de fútbol, incorporando funciones modernas y mejor accesibilidad. Creemos en:
 
 - **Desarrollo Impulsado por la Comunidad** – Tu voz importa
 - **Transparencia** – Puedes ver en qué estamos trabajando
@@ -136,10 +136,10 @@ PJfoot es un proyecto hecho con pasión para recuperar la diversión de los clá
 
 ## ⚽ Construyamos Algo Increíble Juntos
 
-PJfoot existe gracias a jugadores como tú. Cada bug report, sugerencia de funcionalidad y discusión en la comunidad nos ayuda a crear un juego mejor.
+Mister existe gracias a jugadores como tú. Cada bug report, sugerencia de funcionalidad y discusión en la comunidad nos ayuda a crear un juego mejor.
 
 **¿Listo para hacer historia?** Juega, comparte tu opinión y ayúdanos a construir la mejor experiencia retro de manager de fútbol.
 
 ---
 
-*PJfoot – Donde comienza el sueño de cada manager* 🏆
+*Mister – Donde comienza el sueño de cada manager* 🏆

--- a/README.md
+++ b/README.md
@@ -7,16 +7,6 @@ Language: **English** | [Português (Brasil)](README.pt-BR.md) | [Español](READ
 
 ---
 
-> ## 💬 Join Our WhatsApp Community!
-> **Got questions? Want tips? Just want to talk football?**
-> Our managers community is live on WhatsApp — get support, share tactics, and be the first to hear about new releases.
->
-> ### 👉 **[Join the Mister WhatsApp Group](https://chat.whatsapp.com/C4r6lJ09VmQHSTBniDdlVn?mode=gi_t)**
->
-> _Tap the link above on your phone and jump straight in. See you on the pitch!_ ⚽
-
----
-
 # Welcome to Mister ⚽
 
 Ever dreamed of managing your own football club from the ground up? **Mister** is a single-player, retro-styled football manager simulator inspired by the legendary *Elifoot 98* — brought into the modern era with real league data, deep tactics, and a live match engine.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 +-----------------------------------------------------------+
-|                          PJFOOT                           |
+|                          MISTER                           |
 |             Retro Football Manager Community              |
 +-----------------------------------------------------------+
 
@@ -11,24 +11,24 @@ Language: **English** | [Português (Brasil)](README.pt-BR.md) | [Español](READ
 > **Got questions? Want tips? Just want to talk football?**
 > Our managers community is live on WhatsApp — get support, share tactics, and be the first to hear about new releases.
 >
-> ### 👉 **[Join the PJfoot WhatsApp Group](https://chat.whatsapp.com/C4r6lJ09VmQHSTBniDdlVn?mode=gi_t)**
+> ### 👉 **[Join the Mister WhatsApp Group](https://chat.whatsapp.com/C4r6lJ09VmQHSTBniDdlVn?mode=gi_t)**
 >
 > _Tap the link above on your phone and jump straight in. See you on the pitch!_ ⚽
 
 ---
 
-# Welcome to PJfoot ⚽
+# Welcome to Mister ⚽
 
-Ever dreamed of managing your own football club from the ground up? **PJfoot** is a single-player, retro-styled football manager simulator inspired by the legendary *Elifoot 98* — brought into the modern era with real league data, deep tactics, and a live match engine.
+Ever dreamed of managing your own football club from the ground up? **Mister** is a single-player, retro-styled football manager simulator inspired by the legendary *Elifoot 98* — brought into the modern era with real league data, deep tactics, and a live match engine.
 
 Start at the very bottom of the global pyramid. Earn your reputation. Climb through nine divisions. Make history.
 
 ---
 
-## 🎮 What Makes PJfoot Addictive
+## 🎮 What Makes Mister Addictive
 
 ### 🌍 **A Real Global Football Pyramid**
-PJfoot simulates **9 divisions** ranked by IFFHS prestige, featuring real leagues from around the world:
+Mister simulates **9 divisions** ranked by IFFHS prestige, featuring real leagues from around the world:
 
 | Division | League | Country |
 |----------|--------|---------|
@@ -73,7 +73,7 @@ Use **Auto mode** to let the engine pick the best XI by form score, or take **Ma
 ---
 
 ### ⚽ **Live Match Drama**
-Forget instant results. PJfoot plays out every match event by event:
+Forget instant results. Mister plays out every match event by event:
 
 - Goals ⚽, missed chances 💥, yellow cards 🟨, and red cards 🟥 are revealed one by one
 - **Yellow card accumulation** — five yellows on the season earns an automatic one-week ban
@@ -186,9 +186,9 @@ No new gameplay features this time — just everything that makes the game feel 
 
 ---
 
-## 💬 Help Shape PJfoot's Future
+## 💬 Help Shape Mister's Future
 
-**PJfoot is built with you.** The live match feed, card system, half-time substitutions, loan market — all of it shaped by player feedback. Your report today could be tomorrow's feature.
+**Mister is built with you.** The live match feed, card system, half-time substitutions, loan market — all of it shaped by player feedback. Your report today could be tomorrow's feature.
 
 ### 🐛 Found a Bug?
 Describe what happened and we'll get on it fast.
@@ -209,7 +209,7 @@ Talk tactics, share your promotion runs, and help steer the game's direction.
 1. **Be specific** — "The squad table is hard to read on mobile" lands better than "UI is bad"
 2. **Search first** — add your voice to an existing report if it already exists
 3. **Attach evidence** — a screenshot, a save file, or a browser console log helps us reproduce the issue fast
-4. **Be kind** — everyone here loves football games and wants PJfoot to be great
+4. **Be kind** — everyone here loves football games and wants Mister to be great
 5. **Follow up** — if someone asks a clarifying question, you're the expert on your own issue
 
 ---
@@ -224,6 +224,6 @@ Talk tactics, share your promotion runs, and help steer the game's direction.
 
 ---
 
-**PJfoot** is made with ❤️ by the community, for the community.
+**Mister** is made with ❤️ by the community, for the community.
 
 **Start at the bottom. Climb to the top. Make history.** 🏆

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,15 +1,15 @@
 ```
 +-----------------------------------------------------------+
-|                          PJFOOT                           |
+|                          MISTER                           |
 |          Hub da Comunidade do Manager de Futebol          |
 +-----------------------------------------------------------+
 ```
 
 Idioma: [English](README.md) | **Português (Brasil)** | [Español](README.es.md)
 
-# Bem-vindo ao PJfoot
+# Bem-vindo ao Mister
 
-Bem-vindo ao **PJfoot**, o simulador de manager de futebol com estilo retrô inspirado no lendário Elifoot 98! Assuma o controle do seu clube, monte o elenco dos sonhos, enfrente a pressão da temporada e leve seu time ao título.
+Bem-vindo ao **Mister**, o simulador de manager de futebol com estilo retrô inspirado no lendário Elifoot 98! Assuma o controle do seu clube, monte o elenco dos sonhos, enfrente a pressão da temporada e leve seu time ao título.
 
 Acha que tem o que é preciso para ser campeão? Aqui é sua prova.
 
@@ -17,7 +17,7 @@ Acha que tem o que é preciso para ser campeão? Aqui é sua prova.
 
 ## 🎮 Sobre o Jogo
 
-PJfoot é um **simulador single-player de gestão de clube de futebol** com:
+Mister é um **simulador single-player de gestão de clube de futebol** com:
 
 - 🏆 **Competições Profundas** – Dispute em 9 divisões em um sistema global estruturado de ligas
 - 👥 **Gestão de Elenco** – Monte seu time, gerencie fadiga e desenvolva jovens talentos
@@ -79,7 +79,7 @@ Quer ver a evolução do jogo? Confira a jornada completa:
 
 ## 💬 Envie seu Feedback
 
-Estamos construindo o PJfoot com **você** em mente! Seu feedback impacta diretamente o futuro do jogo. Veja como ajudar:
+Estamos construindo o Mister com **você** em mente! Seu feedback impacta diretamente o futuro do jogo. Veja como ajudar:
 
 ### 🐛 Encontrou um Bug?
 Algo não está funcionando como deveria? [Abrir bug report →](../../issues/new?template=bug_report.md)  
@@ -93,7 +93,7 @@ Sugira novas mecânicas, melhorias ou qualquer coisa que você gostaria de ver.
 Quer compartilhar opiniões, tirar dúvidas ou trocar ideia com outros managers? Participe do nosso [fórum de Discussions →](../../discussions)  
 - Compartilhe estratégias e táticas
 - Tire dúvidas com a comunidade
-- Discuta o futuro do PJfoot
+- Discuta o futuro do Mister
 - Conecte-se com outros fãs de futebol
 
 ### 📋 Como dar um ótimo feedback
@@ -115,7 +115,7 @@ Quer compartilhar opiniões, tirar dúvidas ou trocar ideia com outros managers?
 
 ## 🏅 Nossa Visão
 
-PJfoot é um projeto de paixão para resgatar a diversão dos clássicos jogos de manager de futebol, com recursos modernos e mais acessibilidade. Acreditamos em:
+Mister é um projeto de paixão para resgatar a diversão dos clássicos jogos de manager de futebol, com recursos modernos e mais acessibilidade. Acreditamos em:
 
 - **Desenvolvimento Guiado pela Comunidade** – Sua voz importa
 - **Transparência** – Você acompanha tudo o que estamos construindo
@@ -136,10 +136,10 @@ PJfoot é um projeto de paixão para resgatar a diversão dos clássicos jogos d
 
 ## ⚽ Vamos Construir Algo Incrível Juntos
 
-PJfoot existe por causa de jogadores como você. Cada bug report, sugestão de recurso e discussão com a comunidade ajuda a criar um jogo melhor.
+Mister existe por causa de jogadores como você. Cada bug report, sugestão de recurso e discussão com a comunidade ajuda a criar um jogo melhor.
 
 **Pronto para fazer história?** Jogue, compartilhe suas ideias e ajude a construir a melhor experiência retrô de manager de futebol.
 
 ---
 
-*PJfoot – Onde o sonho de todo manager começa* 🏆
+*Mister – Onde o sonho de todo manager começa* 🏆

--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,2 @@
-title: "PJfoot: Press Room & Patch Notes"
+title: "Mister: Press Room & Patch Notes"
 description: "Retro football manager updates, roadmap, and community feedback hub."

--- a/changelog/data/2026.05.02.md
+++ b/changelog/data/2026.05.02.md
@@ -1,4 +1,4 @@
-# PJfoot Data — v2026.05.02
+# Mister Data — v2026.05.02
 
 > Fetched: 2026-05-02T16:30:28.187Z
 

--- a/changelog/data/README.md
+++ b/changelog/data/README.md
@@ -1,4 +1,4 @@
-# PJfoot — Data Changelog
+# Mister — Data Changelog
 
 This directory contains release notes for each versioned data snapshot.
 

--- a/changelog/v0.00.md
+++ b/changelog/v0.00.md
@@ -1,4 +1,4 @@
-# PJfoot v0.00 — Initial Release
+# Mister v0.00 — Initial Release
 
 > Retro-styled football manager simulator inspired by Elifoot 98.
 

--- a/changelog/v0.01.md
+++ b/changelog/v0.01.md
@@ -1,4 +1,4 @@
-# PJfoot v0.01 — League Rankings & New Manager Experience
+# Mister v0.01 — League Rankings & New Manager Experience
 
 > Released: 2026-05-02
 

--- a/changelog/v0.02.md
+++ b/changelog/v0.02.md
@@ -1,4 +1,4 @@
-# PJfoot v0.02 — Squad Management & Player Depth
+# Mister v0.02 — Squad Management & Player Depth
 
 > Released: 2026-05-02
 

--- a/changelog/v0.03.md
+++ b/changelog/v0.03.md
@@ -1,4 +1,4 @@
-# PJfoot v0.03 — Mobile UX, Data Pipeline & Themes
+# Mister v0.03 — Mobile UX, Data Pipeline & Themes
 
 > Released: 2026-05-02
 
@@ -6,7 +6,7 @@
 
 ## Mobile UX Overhaul
 
-PJfoot was designed for desktop. This release rewrites the layout and interaction model to work properly on phones and small screens.
+Mister was designed for desktop. This release rewrites the layout and interaction model to work properly on phones and small screens.
 
 ### Responsive Layout
 

--- a/changelog/v0.04.md
+++ b/changelog/v0.04.md
@@ -1,4 +1,4 @@
-# PJfoot v0.04 — Cup Competition & Calendar Redesign
+# Mister v0.04 — Cup Competition & Calendar Redesign
 
 > Released: 2026-05-02
 
@@ -93,7 +93,7 @@ The code is derived at data-load time from the club's division → league → `c
 
 ## Release Notes Link
 
-The in-app release notes link now points to the [PJfoot Feedback site](https://pejota81.github.io/PJfoot-feedback/).
+The in-app release notes link now points to the [Mister Feedback site](https://pejota81.github.io/PJfoot-feedback/).
 
 ---
 
@@ -114,4 +114,3 @@ Every push to `main` triggers `azure-static-web-apps.yml`, which runs `scripts/f
 **Fix:** Swapped the ranks in `fetch-leagues.mjs`:
 - `DED` (Eredivisie / Netherlands): `iffhsRank: 8`
 - `ELC` (Championship / England): `iffhsRank: 9`
-

--- a/changelog/v0.05.md
+++ b/changelog/v0.05.md
@@ -1,4 +1,4 @@
-# PJfoot v0.05 — Manager Market
+# Mister v0.05 — Manager Market
 
 > Released: 2026-05-02
 
@@ -139,4 +139,3 @@ These fields are stored on the player's `Manager` record alongside name and repu
 Existing cloud saves from v0.04 will load correctly. The `managers` dictionary, `momentum`, `pendingManagerEvent`, and `promotionRejectedUntilSeasonEnd` fields are initialised with safe defaults (`{}`, `50`, `null`, `false`) when loading older saves.
 
 **Note:** older saves will have clubs without `managerId` — start a new game to experience the full manager market feature from week 1.
-

--- a/changelog/v0.06.md
+++ b/changelog/v0.06.md
@@ -1,4 +1,4 @@
-# PJfoot v0.06 — Finance & Stadium Overhaul
+# Mister v0.06 — Finance & Stadium Overhaul
 
 > Released: 2026-05-02
 

--- a/changelog/v0.07.md
+++ b/changelog/v0.07.md
@@ -1,4 +1,4 @@
-# PJfoot v0.07 — Division-Aware Players & Match Realism
+# Mister v0.07 — Division-Aware Players & Match Realism
 
 > Released: 2026-05-02
 

--- a/changelog/v0.08.md
+++ b/changelog/v0.08.md
@@ -1,4 +1,4 @@
-# PJfoot v0.08 — Transfer Market Overhaul & Free Agency
+# Mister v0.08 — Transfer Market Overhaul & Free Agency
 
 > Released: 2026-05-02
 

--- a/changelog/v0.09.md
+++ b/changelog/v0.09.md
@@ -1,4 +1,4 @@
-# PJfoot v0.09 — Tactics Overhaul & Player Stats
+# Mister v0.09 — Tactics Overhaul & Player Stats
 
 > Released: 2026-05-02
 

--- a/changelog/v0.10.md
+++ b/changelog/v0.10.md
@@ -1,4 +1,4 @@
-# PJfoot v0.10 — Match Day Experience & Fixture Balancing
+# Mister v0.10 — Match Day Experience & Fixture Balancing
 
 > Released: 2026-05-02
 

--- a/changelog/v0.11.md
+++ b/changelog/v0.11.md
@@ -1,4 +1,4 @@
-# PJfoot v0.11 — Mobile Polish, Accessibility & Quality Pass
+# Mister v0.11 — Mobile Polish, Accessibility & Quality Pass
 
 > Released: 2026-05-03
 

--- a/changelog/v0.12.md
+++ b/changelog/v0.12.md
@@ -1,4 +1,4 @@
-# PJfoot v0.12 — Live Match, Cards & Post-Match Overhaul
+# Mister v0.12 — Live Match, Cards & Post-Match Overhaul
 
 > Released: 2026-05-03
 

--- a/changelog/v0.13.md
+++ b/changelog/v0.13.md
@@ -1,4 +1,4 @@
-# PJfoot v0.13 — Security, Polish & DevOps Hardening
+# Mister v0.13 — Security, Polish & DevOps Hardening
 
 > Released: 2026-05-03
 

--- a/changelog/v0.14.md
+++ b/changelog/v0.14.md
@@ -1,4 +1,4 @@
-# PJfoot v0.14 — Manager Rankings, Champions Hall & Unified Cup Calendar
+# Mister v0.14 — Manager Rankings, Champions Hall & Unified Cup Calendar
 
 > Released: 2026-05-03
 
@@ -107,4 +107,4 @@ A match context banner now appears at the top of the Tactics screen before every
 
 ---
 
-*PJfoot is an open-source football manager simulation. Data courtesy of football-data.org.*
+*Mister is an open-source football manager simulation. Data courtesy of football-data.org.*

--- a/changelog/v0.15.md
+++ b/changelog/v0.15.md
@@ -1,4 +1,4 @@
-# PJfoot v0.15 — News System, Dashboard Polish & Save Reliability
+# Mister v0.15 — News System, Dashboard Polish & Save Reliability
 
 > Released: 2026-05-03
 
@@ -111,4 +111,4 @@ The "within budget" filter in the Transfers market now checks **both** cash bala
 
 ---
 
-*PJfoot is an open-source football manager simulation. Data courtesy of football-data.org.*
+*Mister is an open-source football manager simulation. Data courtesy of football-data.org.*

--- a/changelog/v0.16.md
+++ b/changelog/v0.16.md
@@ -1,4 +1,4 @@
-# PJfoot v0.16 — Dashboard Layout Refresh, Top Scorers & News Actions
+# Mister v0.16 — Dashboard Layout Refresh, Top Scorers & News Actions
 
 > Released: 2026-05-16
 
@@ -55,4 +55,4 @@ The new dashboard composition and news interactions were tuned to remain clean a
 
 ---
 
-*PJfoot is an open-source football manager simulation. Data courtesy of football-data.org.*
+*Mister is an open-source football manager simulation. Data courtesy of football-data.org.*

--- a/changelog/v0.17.md
+++ b/changelog/v0.17.md
@@ -1,4 +1,4 @@
-# PJfoot v0.17 — Admin Login Key Matching Hardening
+# Mister v0.17 — Admin Login Key Matching Hardening
 
 > Released: 2026-05-16
 

--- a/changelog/v0.18.md
+++ b/changelog/v0.18.md
@@ -1,4 +1,4 @@
-# PJfoot v0.18 — 4-Segment Formation Display & Mobile Responsiveness
+# Mister v0.18 — 4-Segment Formation Display & Mobile Responsiveness
 
 > Released: 2026-05-16
 

--- a/changelog/v0.19.md
+++ b/changelog/v0.19.md
@@ -1,4 +1,4 @@
-# PJfoot v0.19 — Accounts, Profile Settings & Password Recovery
+# Mister v0.19 — Accounts, Profile Settings & Password Recovery
 
 > Released: 2026-05-16
 
@@ -28,4 +28,3 @@ This release introduces first-party user accounts, persistent profile settings, 
 - New Game setup pre-fills manager fields from saved profile defaults.
 - Account settings controls are localized for EN/ES/PT-BR.
 - Account settings layout improved for mobile screens.
-

--- a/changelog/v0.20.md
+++ b/changelog/v0.20.md
@@ -1,4 +1,4 @@
-# PJfoot v0.20 — Auth Flow Simplification
+# Mister v0.20 — Auth Flow Simplification
 
 > Released: 2026-05-16
 

--- a/changelog/v0.21.md
+++ b/changelog/v0.21.md
@@ -1,4 +1,4 @@
-# PJfoot v0.21 - Admin Center Modernization
+# Mister v0.21 - Admin Center Modernization
 
 > Released: 2026-05-16
 

--- a/changelog/v0.22.md
+++ b/changelog/v0.22.md
@@ -1,14 +1,14 @@
-# MISTER v0.22 - Game Renamed to MISTER
+# Mister v0.22 - Game Renamed to Mister
 
 > Released: 2026-05-16
 
-The game has been officially renamed from **PJfoot** to **MISTER**.
+The game has been officially renamed from **PJfoot** to **Mister**.
 
 ---
 
 ## Branding
 
-- Replaced the ASCII art logo on the Main Menu with the new **MISTER** block-letter logo.
-- Updated browser tab title to `MISTER`.
-- Updated the Admin Centre heading to `MISTER Admin Centre`.
-- Updated internal log prefixes to `[MISTER]`.
+- Replaced the ASCII art logo on the Main Menu with the new **Mister** block-letter logo.
+- Updated browser tab title to `Mister`.
+- Updated the Admin Centre heading to `Mister Admin Centre`.
+- Updated internal log prefixes to `[Mister]`.


### PR DESCRIPTION
This updates repository-facing branding to reflect the game rename from PJfoot to Mister so docs, release notes, and automation text stay consistent with the current product name.

### What changed
- Rebranded user-facing documentation in English, Portuguese, and Spanish to use Mister.
- Updated changelog headings and related branding copy to Mister across release and data changelog files.
- Updated issue templates and site config branding text.
- Updated workflow private-repo targets from `pjfoot` to `mister` where mirroring and publishing are configured.
- Updated README automation parsing so it accepts both historical `PJfoot` and current `Mister` changelog title formats.
- Removed the WhatsApp banner section from the top of `README.md`.

### Notes for reviewers
- Repository identifiers and historical references were kept where they are still intentional, such as `PJfoot-feedback` URLs and explicit rename-history text.
- No functional gameplay code was changed; this is a content and workflow branding alignment update.